### PR TITLE
[FIX] Remove unavailable relay

### DIFF
--- a/src/lib/stores/provider.ts
+++ b/src/lib/stores/provider.ts
@@ -50,7 +50,6 @@ export const defaulRelaysUrls: string[] = [
   "wss://purplepag.es",
   "wss://relay.nostr.band",
   "wss://nos.lol",
-  "wss://relay.nostr.net",
 ];
 
 const ndk = new NDKSvelte({


### PR DESCRIPTION
After exploring the web console, an error indicates the hardcoded `wss://relay.nostr.net` is unavailable. 

This PR removes this of the code

![imagen](https://github.com/user-attachments/assets/284b3307-8c1d-4cdf-9d04-2b782bb0a4d3)
![imagen](https://github.com/user-attachments/assets/af20dd00-c817-4618-9f98-14b7796cc14f)

I recommend replacing the relay and adding more relays to a conflux, or using the [NIP65](https://github.com/nostr-protocol/nips/blob/master/65.md) method